### PR TITLE
Testing/1.39.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Download](https://api.bintray.com/packages/bincrafters/public-conan/emsdk_installer%3Abincrafters/images/download.svg) ](https://bintray.com/bincrafters/public-conan/emsdk_installer%3Abincrafters/_latestVersion)
-[![Build Status](https://travis-ci.com/bincrafters/conan-emsdk_installer.svg?branch=stable%2F1.38.22)](https://travis-ci.com/bincrafters/conan-emsdk_installer)
-[![Build status](https://ci.appveyor.com/api/projects/status/github/bincrafters/conan-emsdk_installer?branch=stable%2F1.38.22&svg=true)](https://ci.appveyor.com/project/bincrafters/conan-emsdk-installer)
+[![Build Status](https://travis-ci.com/bincrafters/conan-emsdk_installer.svg?branch=stable%2F1.39.6)](https://travis-ci.com/bincrafters/conan-emsdk_installer)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/bincrafters/conan-emsdk_installer?branch=stable%2F1.39.6&svg=true)](https://ci.appveyor.com/project/bincrafters/conan-emsdk-installer)
 
 [Conan.io](https://conan.io) package recipe for [*emsdk_installer*](https://github.com/kripken/emscripten).
 
@@ -12,14 +12,14 @@ The packages generated with this **conanfile** can be found on [Bintray](https:/
 
 ### Basic setup
 
-    $ conan install emsdk_installer/1.38.22@bincrafters/testing
+    $ conan install emsdk_installer/1.39.6@bincrafters/testing
 
 ### Project setup
 
 If you handle multiple dependencies in your project is better to add a *conanfile.txt*
 
     [requires]
-    emsdk_installer/1.38.22@bincrafters/testing
+    emsdk_installer/1.39.6@bincrafters/testing
 
 
 Complete the installation of requirements for your project running:
@@ -46,7 +46,7 @@ The following command both runs all the steps of the conan file, and publishes t
 
 ## Upload
 
-    $ conan upload emsdk_installer/1.38.22@bincrafters/testing --all -r bincrafters
+    $ conan upload emsdk_installer/1.39.6@bincrafters/testing --all -r bincrafters
 
 
 ## Conan Recipe License

--- a/build.py
+++ b/build.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     settings['compiler'] = 'clang'
     settings['compiler.version'] = '5.0'
     settings['compiler.libcxx'] = 'libc++'
-    settings['arch_build'] = 'x86'
+    settings['arch_build'] = 'x86_64'
     settings['arch'] = 'x86'
 
     if platform.system() == 'Windows':

--- a/build.py
+++ b/build.py
@@ -16,7 +16,8 @@ if __name__ == "__main__":
     settings['compiler'] = 'clang'
     settings['compiler.version'] = '5.0'
     settings['compiler.libcxx'] = 'libc++'
-    settings['arch_build'] = 'x86_64'
+    settings['arch_build'] = 'x86'
+    settings['arch'] = 'x86'
 
     if platform.system() == 'Windows':
         settings['os_build'] = 'Windows'

--- a/conanfile.py
+++ b/conanfile.py
@@ -82,7 +82,7 @@ class EmSDKInstallerConan(ConanFile):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         self.copy(pattern='*', dst='.', src=self._source_subfolder)
         emsdk = self.package_folder
-        emscripten = os.path.join(emsdk, 'emscripten', self.version)
+        emscripten = os.path.join(emsdk, 'upstream', 'emscripten')
         toolchain = os.path.join(emscripten, 'cmake', 'Modules', 'Platform', 'Emscripten.cmake')
         # allow to find conan libraries
         tools.replace_in_file(toolchain,
@@ -105,7 +105,7 @@ class EmSDKInstallerConan(ConanFile):
     def package_info(self):
         emsdk = self.package_folder
         em_config = os.path.join(emsdk, '.emscripten')
-        emscripten = os.path.join(emsdk, 'emscripten', self.version)
+        emscripten = os.path.join(emsdk, 'upstream', 'emscripten')
         em_cache = os.path.join(emsdk, '.emscripten_cache')
         toolchain = os.path.join(emscripten, 'cmake', 'Modules', 'Platform', 'Emscripten.cmake')
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class EmSDKInstallerConan(ConanFile):
 
     settings = {
         "os_build": ['Windows', 'Linux', 'Macos'],
-        "arch_build": ['x86'],
+        "arch_build": ['x86_64'],
         "arch": ['x86'],
     }
     short_paths = True

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,7 +98,7 @@ class EmSDKInstallerConan(ConanFile):
 
     def _define_tool_var(self, name, value):
         suffix = '.bat' if os.name == 'nt' else ''
-        path = os.path.join(self.package_folder, 'emscripten', self.version, '%s%s' % (value, suffix))
+        path = os.path.join(self.package_folder, 'upstream', 'emscripten', '%s%s' % (value, suffix))
         self._chmod_plus_x(path)
         self.output.info('Creating %s environment variable: %s' % (name, path))
         return path

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,8 @@ class EmSDKInstallerConan(ConanFile):
 
     settings = {
         "os_build": ['Windows', 'Linux', 'Macos'],
-        "arch_build": ['x86_64']
+        "arch_build": ['x86'],
+        "arch": ['x86'],
     }
     short_paths = True
     requires = "nodejs_installer/10.15.0@bincrafters/stable"

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class EmSDKInstallerConan(ConanFile):
     name = "emsdk_installer"
-    version = "1.38.29"
+    version = "1.39.6"
     description = "Emscripten is an Open Source LLVM to JavaScript compiler"
     url = "https://github.com/bincrafters/conan-emsdk_installer"
     homepage = "https://github.com/kripken/emscripten"
@@ -75,8 +75,8 @@ class EmSDKInstallerConan(ConanFile):
                    "Windows": "zip"}.get(str(self.settings.os_build))
             self._touch(os.path.join("zips", "node-v8.9.1-%s-x64.%s" % (platform, ext)))
             self._run('%s list' % emsdk)
-            self._run('%s install sdk-%s-64bit' % (emsdk, self.version))
-            self._run('%s activate sdk-%s-64bit --embedded' % (emsdk, self.version))
+            self._run('%s install %s' % (emsdk, self.version))
+            self._run('%s activate %s --embedded' % (emsdk, self.version))
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,8 +21,8 @@ class EmSDKInstallerConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def source(self):
-        commit = "4eeff61368e7471ae543474e2c36869def9a29fc"
-        sha256 = "cb0cce2a985c7b244f80f39be0f328ed2d68e0eb42cdf69fb5b50d68dd68a00f"
+        commit = "997b0a19ff6fdfe0be8b966e1fed05bf5ebf85e4"
+        sha256 = "f8043866f287176ec92a686ea2357ec13c80f6bc781999e1d0130b95ae97f0df"
         source_url = 'https://github.com/emscripten-core/emsdk/archive/%s.tar.gz' % commit
         tools.get(source_url, sha256=sha256)
         extracted_folder = "emsdk-%s" % commit


### PR DESCRIPTION
This installer no longer seems to be building. I had a go at fixing it, hope this helps!

 - Emsdk precompiled downloads have moved from aws to google cloud. This updates the sdk.
 - 1.38.29 was no longer suggested by the sdk, instead we use 1.39.6. That means the branch should probably be changed.
 - It looks like the Emscripten.cmake path has changed, and is now correct again.
 - MinGW started complaining about usage of -m64 with webassembly. So this changes the architecture as well.