### PR TITLE
Updating the installation to the latest version 1.39.13

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,25 @@
+sources:
+  1.39.13:
+    url: "https://github.com/emscripten-core/emsdk/archive/1.39.13.tar.gz"
+    sha256: "fe715f382ccbd675a3365dc75251af10fceca760fdca2524959eb96829de3fc1"
+  1.39.12:
+    url: "https://github.com/emscripten-core/emsdk/archive/1.39.12.tar.gz"
+    sha256: "3c2563cdfc64531bceaa86105d5fd310b2499ed507159c7916cc4c4f5049909d"
+  1.39.11:
+    url: "https://github.com/emscripten-core/emsdk/archive/1.39.11.tar.gz"
+    sha256: "d1f0d70a09434653e9f651c017bac58efa1892469942c6a46e5bcd75b8308dd6"    
+  1.39.10:
+      url: "https://github.com/emscripten-core/emsdk/archive/1.39.10.tar.gz"
+      sha256: "d786948f7366b383a46154b5906da50cc6d59cad81acd6ecc82e9d20f3c10c9f"
+  1.39.9:
+      url: "https://github.com/emscripten-core/emsdk/archive/1.39.9.tar.gz"
+      sha256: "dadd3af3c67a809280ffe9c23fcfe7c115eaddd8c8b4ff1ff6e55387d945a368"
+  1.39.8:
+      url: "https://github.com/emscripten-core/emsdk/archive/1.39.8.tar.gz"
+      sha256: "37b8807cad1aa0a976bbbdee5d3c5efc03e59175efdc555721793824f8c591f4"
+  1.39.7:
+      url: "https://github.com/emscripten-core/emsdk/archive/1.39.7.tar.gz"
+      sha256: "af4cb2f4fd19184bd6bc60add730203e566afc70d067569bd70824e19df55ddc"
+  1.39.6:
+    url: "https://github.com/emscripten-core/emsdk/archive/1.39.6.tar.gz"
+    sha256: "4ac0f1f3de8b3f1373d435cd7e58bd94de4146e751f099732167749a229b443b"

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ class EmSDKInstallerConan(ConanFile):
     description = "Emscripten is an Open Source LLVM to JavaScript compiler"
     url = "https://github.com/bincrafters/conan-emsdk_installer"
     homepage = "https://github.com/kripken/emscripten"
-    topcis = ("conan", "emsdk", "emscripten", "installer", "sdk")
+    topics = ("conan", "emsdk", "emscripten", "installer", "sdk")
     license = "MIT"
 
     settings = {

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class EmSDKInstallerConan(ConanFile):
         "arch": ['x86'],
     }
     short_paths = True
-    requires = "nodejs_installer/10.15.0@bincrafters/stable"
+    requires = "nodejs/12.14.1"
     _source_subfolder = "source_subfolder"
 
     def source(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,6 @@ import os
 
 class EmSDKInstallerConan(ConanFile):
     name = "emsdk_installer"
-    version = "1.39.6"
     description = "Emscripten is an Open Source LLVM to JavaScript compiler"
     url = "https://github.com/bincrafters/conan-emsdk_installer"
     homepage = "https://github.com/kripken/emscripten"
@@ -21,11 +20,9 @@ class EmSDKInstallerConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def source(self):
-        commit = "997b0a19ff6fdfe0be8b966e1fed05bf5ebf85e4"
-        sha256 = "f8043866f287176ec92a686ea2357ec13c80f6bc781999e1d0130b95ae97f0df"
-        source_url = 'https://github.com/emscripten-core/emsdk/archive/%s.tar.gz' % commit
-        tools.get(source_url, sha256=sha256)
-        extracted_folder = "emsdk-%s" % commit
+        source_url = 'https://github.com/emscripten-core/emsdk/archive/%s.tar.gz' % self.version
+        tools.get(source_url)
+        extracted_folder = "emsdk-%s" % self.version
         os.rename(extracted_folder, self._source_subfolder)
 
     def _run(self, command):

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,8 +20,7 @@ class EmSDKInstallerConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def source(self):
-        source_url = 'https://github.com/emscripten-core/emsdk/archive/%s.tar.gz' % self.version
-        tools.get(source_url)
+        tools.get(**self.conan_data["sources"][self.version])
         extracted_folder = "emsdk-%s" % self.version
         os.rename(extracted_folder, self._source_subfolder)
 


### PR DESCRIPTION
Hello Everyone,

Probably this PR should be merge into a new branch called testing/1.39.13 (?)

This PR changes:
* the nodejs to the latest official version
* generalizes the script, so it can build all the 1.39.* versions. Now someone has just to type conan create . 1.39.*@user/testing -s arch=x86 to create the emsdk package.


Some open questions. 
* commit 021d417ba7f1bf108fddd87bacf7bd24b68c30ed is forcing now the arch to x86. This probably contradicts the official documentation (https://docs.conan.io/en/latest/integrations/cross_platform/emscripten.html). I can understand the logic behind it (since the new wasm back end is 32bit), but maybe it is better to rename the arch to wasm. I am suggesting that so we could also distinguish between the new llvm backed and the old asm.js backed. Technically the old backed is still available and can be still installed if someone adapts the recipe. What do you think? 

KR,

Vasileios